### PR TITLE
fix NPE

### DIFF
--- a/app/src/main/java/io/github/yusukeiwaki/githubviewer/background_fetch/BackgroundFetchJob.java
+++ b/app/src/main/java/io/github/yusukeiwaki/githubviewer/background_fetch/BackgroundFetchJob.java
@@ -40,6 +40,7 @@ public class BackgroundFetchJob extends Job {
     protected Result onRunJob(Params params) {
         final CountDownLatch countDownLatch = new CountDownLatch(1);
         final ResultRef<Boolean> resultRef = new ResultRef<>();
+        resultRef.result = false;
 
         RealmHelper.executeTransaction(new RealmHelper.Transaction() {
             @Override


### PR DESCRIPTION
```
12-30 00:57:32.701 E/JobExecutor( 5253): Crashed job{id=3, finished=true, result=FAILURE, canceled=false, periodic=true, class=BackgroundFetchJob, tag=BackgroundFetchJob}
12-30 00:57:32.701 E/JobExecutor( 5253): java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.Boolean.booleanValue()' on a null object reference
12-30 00:57:32.701 E/JobExecutor( 5253): 	at io.github.yusukeiwaki.githubviewer.background_fetch.BackgroundFetchJob.onRunJob(BackgroundFetchJob.java:97)
12-30 00:57:32.701 E/JobExecutor( 5253): 	at com.evernote.android.job.Job.runJob(Job.java:109)
12-30 00:57:32.701 E/JobExecutor( 5253): 	at com.evernote.android.job.JobExecutor$JobCallable.runJob(JobExecutor.java:150)
12-30 00:57:32.701 E/JobExecutor( 5253): 	at com.evernote.android.job.JobExecutor$JobCallable.call(JobExecutor.java:135)
12-30 00:57:32.701 E/JobExecutor( 5253): 	at com.evernote.android.job.JobExecutor$JobCallable.call(JobExecutor.java:118)
12-30 00:57:32.701 E/JobExecutor( 5253): 	at java.util.concurrent.FutureTask.run(FutureTask.java:237)
12-30 00:57:32.701 E/JobExecutor( 5253): 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
12-30 00:57:32.701 E/JobExecutor( 5253): 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
12-30 00:57:32.701 E/JobExecutor( 5253): 	at java.lang.Thread.run(Thread.java:818)
```

fix this.